### PR TITLE
[FEAT] : 마크다운으로 작성된 회원 템플릿을 HTML로 반환

### DIFF
--- a/src/main/java/com/sic/marktory/member_template/command/application/controller/MemberTemplateController.java
+++ b/src/main/java/com/sic/marktory/member_template/command/application/controller/MemberTemplateController.java
@@ -17,9 +17,10 @@ public class MemberTemplateController {
     // TODO: 템플릿을 작성할 때 회원의 id가 필요. 이 코드에서는 테스트를 위해서 임의로 설정
     // TODO: request 값이 null 인 경우의 처리 필요
     @PostMapping()
-    public ResponseEntity<Long> postCreateMemberTemplate(@RequestBody MemberTemplateCreateRequest request) {
-        Long id = memberTemplateService.createMemberTemplate(request);
-        return ResponseEntity.ok(id);
+    public ResponseEntity<String> postCreateMemberTemplate(@RequestBody MemberTemplateCreateRequest request) {
+        String result = memberTemplateService.createMemberTemplate(request);
+        return ResponseEntity.ok()
+                .header("Content-Type", "text/html").body(result);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/sic/marktory/member_template/command/application/service/MemberTemplateService.java
+++ b/src/main/java/com/sic/marktory/member_template/command/application/service/MemberTemplateService.java
@@ -6,7 +6,7 @@ import com.sic.marktory.member_template.command.application.dto.MemberTemplateUp
 public interface MemberTemplateService {
 
     // 사용자가 템플릿을 작성
-    Long createMemberTemplate(MemberTemplateCreateRequest request);
+    String createMemberTemplate(MemberTemplateCreateRequest request);
 
     // 사용자 템플릿 수정
     void updateMemberTemplate(Long id, MemberTemplateUpdateRequest request);

--- a/src/main/java/com/sic/marktory/member_template/command/application/service/MemberTemplateServiceImpl.java
+++ b/src/main/java/com/sic/marktory/member_template/command/application/service/MemberTemplateServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sic.marktory.member_template.command.application.service;
 
 import com.sic.marktory.common.DateTimeUtil;
+import com.sic.marktory.common.MarkdownUtil;
 import com.sic.marktory.member_template.command.application.dto.MemberTemplateCreateRequest;
 import com.sic.marktory.member_template.command.application.dto.MemberTemplateUpdateRequest;
 import com.sic.marktory.member_template.command.domain.aggregate.MemberTemplateEntity;
@@ -21,19 +22,23 @@ public class MemberTemplateServiceImpl implements MemberTemplateService {
     // 회원이 템플릿을 작성
     @Override
     @Transactional
-    public Long createMemberTemplate(MemberTemplateCreateRequest request) {
+    public String createMemberTemplate(MemberTemplateCreateRequest request) {
+        String html ="<body><html>" + MarkdownUtil.toHtml(request.getContent()) + "</body></html>";
+
         MemberTemplateEntity template = MemberTemplateEntity.builder()
                 .title(request.getTitle())
-                .content(request.getContent())
+                .content(html)
                 .writtenDate(DateTimeUtil.nowFormatted())
-//                .visibility(new Visibility(request.getVisibility()))
+                .visibility(new Visibility(request.getVisibility()))
                 .usageCount(0)
                 .isCopy('N')
                 // TODO : 회원의 id를 받아서 생성해야 함. 현재는 command 구조 테스트를 위한 코드임.
                 .repositoryId(request.getRepositoryId())
                 .build();
 
-        return memberTemplateRepository.save(template).getId();
+        memberTemplateRepository.save(template);
+
+        return html;
     }
 
     // 회원이 특정 템플릿을 수정

--- a/src/main/java/com/sic/marktory/member_template/command/domain/aggregate/MemberTemplateEntity.java
+++ b/src/main/java/com/sic/marktory/member_template/command/domain/aggregate/MemberTemplateEntity.java
@@ -24,7 +24,7 @@ public class MemberTemplateEntity {
     private String title;
 
     @Lob
-    @Column(name = "content", nullable = false)
+    @Column(name = "content", nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
     @Column(name="written_date" , nullable = false)


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
- 사용자가 작성한 마크다운 언어를 HTML로 변환하여 사용자에게 return 하는 기능
- 예외처리 안되어 있음

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#70`)

## ✅ 체크리스트 (Checklist)
- [ ] 코드에 오류가 없는지 확인하셨나요?
- [ ] 주요 변경 사항을 문서화하셨나요?
- [ ] 단위 테스트 또는 통합 테스트를 추가했나요? (해당하는 경우)
- [ ] 리뷰어가 확인해야 할 포인트가 있다면 적어주세요.

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

@Jooahyeon 이걸 게시글 작성과 query에도 그대로 적용하면 좋을거 같습니다.

<img width="924" alt="image" src="https://github.com/user-attachments/assets/435d553c-9d68-423c-a0b8-159eea287cbc" />

