### PR TITLE
[FEAT] 마이페이지 Query 기능 구현

### DIFF
--- a/src/main/java/com/sic/marktory/member/command/application/service/MemberService.java
+++ b/src/main/java/com/sic/marktory/member/command/application/service/MemberService.java
@@ -3,6 +3,7 @@ package com.sic.marktory.member.command.application.service;
 import com.sic.marktory.member.command.application.dto.EmailTokenDTO;
 import com.sic.marktory.member.command.application.dto.MemberDTO;
 import com.sic.marktory.member.common.exception.NickNameException;
+import com.sic.marktory.member.query.dto.MemberPageDTO;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/sic/marktory/member/query/controller/MemberController.java
+++ b/src/main/java/com/sic/marktory/member/query/controller/MemberController.java
@@ -1,22 +1,61 @@
 package com.sic.marktory.member.query.controller;
 
+import com.sic.marktory.member.query.dto.MemberAndCommentDTO;
+import com.sic.marktory.member.query.dto.MemberAndPostDTO;
+import com.sic.marktory.member.query.dto.MemberAndTemplateDTO;
+import com.sic.marktory.member.query.dto.MemberPageDTO;
 import com.sic.marktory.member.query.service.MemberService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController("memberQueryController")
 @RequestMapping("api/member")
+@Slf4j
 public class MemberController {
 
-    /* 설명. 로그인을 위한 조회 */
-    private MemberService memberSerivce;
+    private final MemberService memberService;
 
     @Autowired
-    public MemberController(@Qualifier("queryMemberService") MemberService memberSerivce) {
-        this.memberSerivce = memberSerivce;
+    public MemberController(@Qualifier("queryMemberService") MemberService memberService) {
+        this.memberService = memberService;
     }
 
+    /* 설명. 회원 페이지 조회 */
+    @GetMapping("mypage/{memberId}")
+    public ResponseEntity<MemberPageDTO> getMembers(@PathVariable Long memberId) {
+        MemberPageDTO memberPageDTO = memberService.findById(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(memberPageDTO);
+    }
+
+    /* 설명. 회원 페이지에서 내가 작성한 게시글 조회 */
+    @GetMapping("mypage/{memberId}/my-post")
+    public ResponseEntity<List<MemberAndPostDTO>> getMemberAndPosts(@PathVariable Long memberId) {
+        List<MemberAndPostDTO> resultSet = memberService.findByIdAndPost(memberId);
+        log.info(resultSet.toString());
+        return ResponseEntity.status(HttpStatus.OK).body(resultSet);
+    }
+    /* 설명. 회원 페이지에서 내가 작성한 댓글 조회 */
+    @GetMapping("mypage/{memberId}/my-comment")
+    public ResponseEntity<List<MemberAndCommentDTO>> getMemberAndComoments(@PathVariable Long memberId){
+        List<MemberAndCommentDTO> resultSet = memberService.findByIdAndComment(memberId);
+        log.info(resultSet.toString());
+        return ResponseEntity.status(HttpStatus.OK).body(resultSet);
+    }
+    /* 설명. 회원 페이지에서 내 템플릿 저장소 확인 */
+    @GetMapping("mypage/{memberId}/member-template")
+    public ResponseEntity<List<MemberAndTemplateDTO>> getMemberTemplates(@PathVariable Long memberId) {
+        List<MemberAndTemplateDTO> resultSet = memberService.findByIdAndTemplate(memberId);
+        return ResponseEntity.status(HttpStatus.OK).body(resultSet);
+    }
+
+    /* 설명. 회원 페이지에서 내 게시글에 달린 댓글 확인 */
 }

--- a/src/main/java/com/sic/marktory/member/query/dto/MemberAndCommentDTO.java
+++ b/src/main/java/com/sic/marktory/member/query/dto/MemberAndCommentDTO.java
@@ -1,0 +1,13 @@
+package com.sic.marktory.member.query.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter @Setter
+@ToString
+public class MemberAndCommentDTO {
+    private String nickname;
+    private String content;
+    private String writtenDate;
+}

--- a/src/main/java/com/sic/marktory/member/query/dto/MemberAndPostDTO.java
+++ b/src/main/java/com/sic/marktory/member/query/dto/MemberAndPostDTO.java
@@ -1,0 +1,14 @@
+package com.sic.marktory.member.query.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class MemberAndPostDTO {
+    private String title;
+    private String nickname;
+    private String content;
+}

--- a/src/main/java/com/sic/marktory/member/query/dto/MemberAndTemplateDTO.java
+++ b/src/main/java/com/sic/marktory/member/query/dto/MemberAndTemplateDTO.java
@@ -1,0 +1,16 @@
+package com.sic.marktory.member.query.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter @Setter
+@ToString
+public class MemberAndTemplateDTO {
+    private String nickname;
+    private String title;
+    private String content;
+    private String writtenDate;
+    private String visibility;
+    private Boolean isCopy;
+}

--- a/src/main/java/com/sic/marktory/member/query/dto/MemberPageDTO.java
+++ b/src/main/java/com/sic/marktory/member/query/dto/MemberPageDTO.java
@@ -1,0 +1,15 @@
+package com.sic.marktory.member.query.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter @Setter
+@ToString
+public class MemberPageDTO {
+    private String nickname;
+    private String image;
+    private String assignedDate;
+}

--- a/src/main/java/com/sic/marktory/member/query/mapper/MemberMapper.java
+++ b/src/main/java/com/sic/marktory/member/query/mapper/MemberMapper.java
@@ -1,12 +1,21 @@
 package com.sic.marktory.member.query.mapper;
 
-import com.sic.marktory.member.query.dto.MemberDTO;
-import com.sic.marktory.member.query.dto.MemberWithRoleDTO;
+import com.sic.marktory.member.query.dto.*;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface MemberMapper {
     MemberDTO selectByEmail(String email);
 
     MemberWithRoleDTO selectMemberWithRoleByEmail(String email);
+
+    MemberPageDTO selectById(Long memberId);
+
+    List<MemberAndPostDTO> selectByIdAndPost(Long memberId);
+
+    List<MemberAndCommentDTO> selectByIdAndComment(Long memberId);
+
+    List<MemberAndTemplateDTO> selectByIdAndTemplate(Long memberId);
 }

--- a/src/main/java/com/sic/marktory/member/query/service/MemberService.java
+++ b/src/main/java/com/sic/marktory/member/query/service/MemberService.java
@@ -1,8 +1,22 @@
 package com.sic.marktory.member.query.service;
 
+import com.sic.marktory.member.query.dto.MemberAndCommentDTO;
+import com.sic.marktory.member.query.dto.MemberAndPostDTO;
+import com.sic.marktory.member.query.dto.MemberAndTemplateDTO;
+import com.sic.marktory.member.query.dto.MemberPageDTO;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
+import java.util.List;
+
 public interface MemberService extends UserDetailsService {
     UserDetails loadUserByUsername(String email);
+
+    MemberPageDTO findById(Long memberId);
+
+    List<MemberAndPostDTO> findByIdAndPost(Long memberId);
+
+    List<MemberAndCommentDTO> findByIdAndComment(Long memberId);
+
+    List<MemberAndTemplateDTO> findByIdAndTemplate(Long memberId);
 }

--- a/src/main/java/com/sic/marktory/member/query/service/MemberServiceImpl.java
+++ b/src/main/java/com/sic/marktory/member/query/service/MemberServiceImpl.java
@@ -1,6 +1,6 @@
 package com.sic.marktory.member.query.service;
 
-import com.sic.marktory.member.query.dto.MemberWithRoleDTO;
+import com.sic.marktory.member.query.dto.*;
 import com.sic.marktory.member.query.mapper.AuthorityMapper;
 import com.sic.marktory.member.query.mapper.MemberMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -53,4 +53,29 @@ public class MemberServiceImpl implements MemberService {
                 true,
                 true, grantedAuthorities);
     }
+
+    @Override
+    public MemberPageDTO findById(Long memberId) {
+        return memberMapper.selectById(memberId);
+    }
+
+    /* 설명. 마이페이지에서 내가 작성한 게시글 조회 완료 */
+    @Override
+    public List<MemberAndPostDTO> findByIdAndPost(Long memberId) {
+        List<MemberAndPostDTO> resultSet = memberMapper.selectByIdAndPost(memberId);
+        return resultSet;
+    }
+
+    @Override
+    public List<MemberAndCommentDTO> findByIdAndComment(Long memberId) {
+        List<MemberAndCommentDTO> resultSet = memberMapper.selectByIdAndComment(memberId);
+        return resultSet;
+    }
+
+    @Override
+    public List<MemberAndTemplateDTO> findByIdAndTemplate(Long memberId) {
+        List<MemberAndTemplateDTO> resultSet = memberMapper.selectByIdAndTemplate(memberId);
+        return resultSet;
+    }
+
 }

--- a/src/main/resources/com/sic/marktory/member/query/mapper/MemberMapper.xml
+++ b/src/main/resources/com/sic/marktory/member/query/mapper/MemberMapper.xml
@@ -3,6 +3,7 @@
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.sic.marktory.member.query.mapper.MemberMapper">
+    <!-- 전체 정보 조회(혹시몰라) -->
     <resultMap id="memberMap" type="com.sic.marktory.member.query.dto.MemberDTO">
         <id property="id" column="id"/>
         <result property="email" column="email"/>
@@ -26,6 +27,32 @@
         <result property="role" column="name"/> <!-- 권한 조인 결과 -->
     </resultMap>
 
+    <resultMap id="memberPageMap" type="com.sic.marktory.member.query.dto.MemberPageDTO">
+        <result property="email" column="email"/>
+        <result property="image" column="image"/>
+        <result property="assignedDate" column="assigned_date"/>
+    </resultMap>
+
+    <resultMap id="memberAndPostMap" type="com.sic.marktory.member.query.dto.MemberAndPostDTO">
+        <result property="title" column="title"/>
+        <result property="nickname" column="nickname"/>
+        <result property="content" column="content"/>
+    </resultMap>
+
+    <resultMap id="memberAndCommentMap" type="com.sic.marktory.member.query.dto.MemberAndCommentDTO">
+        <result property="nickname" column="nickname"/>
+        <result property="content" column="content"/>
+        <result property="writtenDate" column="written_date"/>
+    </resultMap>
+
+    <resultMap id="memberAndTemplateMap" type="com.sic.marktory.member.query.dto.MemberAndTemplateDTO">
+        <result property="nickname" column="nickname"/>
+        <result property="title" column="title"/>
+        <result property="content" column="content"/>
+        <result property="writtenDate" column="written_date"/>
+        <result property="visibility" column="visibility"/>
+        <result property="isCopy" column="is_copy"/>
+    </resultMap>
     <!-- 2. 3중 조인 문 -->
     <select id="selectMemberWithRoleByEmail" parameterType="string" resultMap="memberWithRoleMap">
         SELECT
@@ -39,4 +66,49 @@
          WHERE A.email = #{email}
     </select>
 
+
+    <!-- 마이페이지 조회하기 -->
+    <select id="selectById" parameterType="_long" resultMap="memberPageMap">
+        SELECT
+               nickname
+             , image
+             , assigned_date
+          FROM member
+         WHERE id = #{id};
+    </select>
+
+    <!-- 마이페이지/추가 기능 내가 작성한 게시글 목록 -->
+    <select id="selectByIdAndPost" parameterType="_long" resultMap="memberAndPostMap">
+        SELECT
+               B.title
+             , A.nickname
+             , B.content
+          FROM member A
+          JOIN post B ON A.id = B.member_id
+         WHERE A.id = #{id}
+    </select>
+    <!-- 마이페이지/추가 기능 내가 작성한 댓글 목록 -->
+    <select id="selectByIdAndComment" parameterType="_long" resultMap="memberAndCommentMap">
+        SELECT
+               A.nickname
+             , B.content
+             , B.written_date
+          FROM member A
+          JOIN comment B ON (A.id = B.member_id)
+         WHERE A.id = #{id};
+    </select>
+    <!-- 마이페이지/ 내 템플릿 저장소 확인 -->
+    <select id="selectByIdAndTemplate" parameterType="_long" resultMap="memberAndTemplateMap">
+        SELECT
+               A.nickname
+             , C.title
+             , C.content
+             , C.written_date
+             , C.visibility
+             , C.is_copy
+          FROM member A
+          JOIN template_space B ON (A.id = B.member_id)
+          JOIN member_template C ON (B.id = C.repository_id)
+         WHERE A.id = #{id};
+    </select>
 </mapper>

--- a/src/main/resources/sql/member/member_mypage.sql
+++ b/src/main/resources/sql/member/member_mypage.sql
@@ -9,6 +9,7 @@ SELECT
 # 로그인 된 상태로, 마이페이지에서 내가 작성한 게시글 확인
 SELECT
        B.title
+     , A.nickname
      , B.content
   FROM member A
          JOIN post B ON (A.id = B.member_id)
@@ -16,8 +17,11 @@ WHERE A.id = ?;
 
 # 로그인 된 상태로, 마이페이지에서 내 템플릿 저장소 확인
 SELECT
-       C.title
+       A.nickname
+     , C.title
      , C.content
+     , C.visibility
+     , C.is_copy
   FROM member A
   JOIN template_space B ON (A.id = B.member_id)
   JOIN member_template C ON (B.id = C.repository_id)
@@ -35,5 +39,12 @@ SELECT
 
 # 내 모든 게시글에, 달린 댓글 한번에 확인
 SELECT
+       D.nickname
+     , C.content AS comment_content
+     , B.title AS post_title
+     , B.id AS post_id
   FROM member A
-  JOIN post B ON (A.id = B.member_id)
+  JOIN post B ON A.id = B.member_id
+  JOIN comment C ON B.id = C.post_id
+  JOIN member D ON C.member_id = D.id  -- 댓글 단 사람: D
+ WHERE A.id = ?;


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
마이페이지 구현, 토큰 방식으로 인증을 사용
마이페이지 기본 닉네임, 프로필 사진, 가입 날짜
마이페이지 사용자가 작성한 게시글, 댓글, 템플릿 저장소 조회 구현

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- #31 

## ✅ 체크리스트 (Checklist)
- [ ] 코드에 오류가 없는지 확인하셨나요?
- [ ] 주요 변경 사항을 문서화하셨나요?
- [ ] 단위 테스트 또는 통합 테스트를 추가했나요? (해당하는 경우)
- [ ] 리뷰어가 확인해야 할 포인트가 있다면 적어주세요.

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/20dd48e6-a3b9-486d-a7f1-b623d487e184" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/5551e866-3896-4e81-b6e5-d98ae89a0d74" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c959cc06-4b53-44b4-a597-069e2dfd68d6" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/af2c973e-4ac1-4eb1-a1a2-b7640744a521" />

---
