### PR TITLE
[CHORE] main server 테스트 환경 구성

### DIFF
--- a/gateway-server-start.sh
+++ b/gateway-server-start.sh
@@ -2,4 +2,5 @@ cd gateway-server
 #./gradlew build --refresh-dependencies
 ./gradlew build -x test
 cd build/libs
-java -jar gatewayserver-0.0.1-SNAPSHOT.jar
+#java -jar gatewayserver-0.0.1-SNAPSHOT.jar # 실제 배포시 활성화
+java -Dspring.profiles.active=test -jar gatewayserver-0.0.1-SNAPSHOT.jar # 테스트용 실행 명령어

--- a/main-server-start.sh
+++ b/main-server-start.sh
@@ -2,4 +2,10 @@ cd main-server
 #./gradlew build --refresh-dependencies
 ./gradlew build -x test
 cd build/libs
-java -jar marktory-0.0.2-SNAPSHOT.jar
+#java -jar marktory-0.0.2-SNAPSHOT.jar # 실제 배포시 활성화
+java -Dspring.profiles.active=test -jar marktory-0.0.2-SNAPSHOT.jar # 테스트용 실행 명령어
+
+# 테스트용 실행을 한다면 추가적으로 main-server yml에서 아래의 코드 주석 처리 필요
+#token:
+#  expiration_time: 43200000
+#  secret: u7uSfjpMtBgE9vQJg6N95arlkv8pv1yjitGOlM0bI9wKMxVeaCflPsysAPS1768PpW1RuOcpMxI3yB4WCQw77Q==

--- a/main-server/src/main/java/com/sic/marktory/common/security/JwtFilter.java
+++ b/main-server/src/main/java/com/sic/marktory/common/security/JwtFilter.java
@@ -6,19 +6,24 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final Environment environment;
 
-    public JwtFilter(JwtUtil jwtUtil) {
+    public JwtFilter(JwtUtil jwtUtil, Environment environment) {
         this.jwtUtil = jwtUtil;
+        this.environment = environment;
     }
 
     @Override
@@ -26,8 +31,12 @@ public class JwtFilter extends OncePerRequestFilter {
         String authorizationHeader = request.getHeader("Authorization");
         log.info("들고 온 토큰 확인: {}", authorizationHeader);
 
-
-        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+        // test 모드를 위해 상단 if문 추가 (테스트 모드 토큰을 통과시켜야함ㅋ)
+        if (isTestProfileActive()) {
+            log.info("test 프로필 - 토큰 없이 인증 객체 강제 주입");
+            Authentication authentication = new UsernamePasswordAuthenticationToken("test-user", null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             String token = authorizationHeader.substring(7);    // "Bearer "를 제외한 토큰 부분만 추출
             log.info("순수 토큰 값: " + token);
             if(jwtUtil.validateToken(token)) {
@@ -42,5 +51,9 @@ public class JwtFilter extends OncePerRequestFilter {
 
         /* 설명. 다음 필터를 진행하게 해 줘야 AuthenticationFilter가 동작함 */
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isTestProfileActive() {
+        return List.of(environment.getActiveProfiles()).contains("test");
     }
 }

--- a/main-server/src/main/java/com/sic/marktory/common/security/JwtUtil.java
+++ b/main-server/src/main/java/com/sic/marktory/common/security/JwtUtil.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
+@Profile("!test")
 public class JwtUtil {
 
     private final Key key;     // 의존성 주입

--- a/main-server/src/main/java/com/sic/marktory/common/security/TestJwtUtil.java
+++ b/main-server/src/main/java/com/sic/marktory/common/security/TestJwtUtil.java
@@ -1,0 +1,32 @@
+package com.sic.marktory.common.security;
+
+import com.sic.marktory.member.service.MemberVerifyService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.List;
+
+@Component
+@Profile("test")  // test 환경에서만 이 빈이 등록됨
+public class TestJwtUtil extends JwtUtil {
+
+    public TestJwtUtil(MemberVerifyService memberVerifyService) {
+        // 부모 생성자에 아무 키나 넣어도 됨 (어차피 validateToken 무시됨)
+        super( Base64.getEncoder().encodeToString("this-is-a-test-secret-key-1234567890".getBytes()), memberVerifyService);
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        // 무조건 유효한 토큰으로 간주
+        return true;
+    }
+
+    @Override
+    public Authentication getAuthentication(String token) {
+        // test 인증 객체 생성 (권한 없음)
+        return new UsernamePasswordAuthenticationToken("test-user", null, List.of());
+    }
+}

--- a/main-server/src/main/java/com/sic/marktory/common/security/WebSecurity.java
+++ b/main-server/src/main/java/com/sic/marktory/common/security/WebSecurity.java
@@ -73,7 +73,7 @@ public class WebSecurity {
 
         /* 설명. 로그인 이후 사용자가 들고 온 (request header에 발급받은 bearer 토큰을 들고 옴)
             토큰을 검증하기 위한 필터 */
-        http.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtFilter(jwtUtil, env), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.

main 서버와 gateway 서버에 테스트용 token 우회 코드 삽입

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- #93 

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

gateway-server와 main-server에 token 우회를 위한 코드를 삽입했습니다. 
또한 gateway-server-start.sh와 main-server-start.sh에 각각 기존 "#java -jar marktory-0.0.2-SNAPSHOT.jar" 를 주석처리하고
"java -Dspring.profiles.active=test -jar marktory-0.0.2-SNAPSHOT.jar" 를 삽입하여 token 우회를 위한 build가 되도록 했습니다.

main-server에서 테스트 build를 하여 token을 우회하기 위해서는 추가적으로 yml에 token 관련 설정 코드를 주석해줘야 하는 번거로움은 있습니다. (반대로 정식 build시에도 token 관련 설정 코드를 다시 주석을 해제 해야 합니다.)

---
